### PR TITLE
Add speech to text capability

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <uses-permission
         android:name="android.permission.BLUETOOTH_ADVERTISE"

--- a/composeApp/src/androidMain/kotlin/di/Modules.android.kt
+++ b/composeApp/src/androidMain/kotlin/di/Modules.android.kt
@@ -8,6 +8,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import persistence.createDataStore
+import services.SpeechToText
 import robo.ndipatri.robogaggia.proto_datastore_kmm.TelemetryProtoData
 
 actual val platformModule = module {
@@ -21,4 +22,8 @@ actual val dataStoreModule = module {
         val producePath = { androidContext().filesDir.resolve(DATA_STORE_FILE_NAME).absolutePath.toPath() }
         createDataStore(fileSystem = FileSystem.SYSTEM, producePath = producePath)
     }
+}
+
+actual val speechToTextModule = module {
+    single { SpeechToText(get<ApplicationContextWrapper>().applicationContext) }
 }

--- a/composeApp/src/androidMain/kotlin/services/SpeechToText.android.kt
+++ b/composeApp/src/androidMain/kotlin/services/SpeechToText.android.kt
@@ -1,0 +1,44 @@
+package services
+
+import android.content.Intent
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import dev.bluefalcon.ApplicationContext
+
+actual class SpeechToText actual constructor(private val context: ApplicationContext) {
+    private var callback: ((String) -> Unit)? = null
+    private val recognizer: SpeechRecognizer = SpeechRecognizer.createSpeechRecognizer(context as android.content.Context).apply {
+        setRecognitionListener(object : RecognitionListener {
+            override fun onResults(results: Bundle?) {
+                results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()?.let { callback?.invoke(it) }
+            }
+
+            override fun onPartialResults(partialResults: Bundle?) {
+                partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()?.let { callback?.invoke(it) }
+            }
+
+            override fun onError(error: Int) {}
+            override fun onReadyForSpeech(params: Bundle?) {}
+            override fun onBeginningOfSpeech() {}
+            override fun onRmsChanged(rmsdB: Float) {}
+            override fun onBufferReceived(buffer: ByteArray?) {}
+            override fun onEndOfSpeech() {}
+            override fun onEvent(eventType: Int, params: Bundle?) {}
+        })
+    }
+
+    actual fun startListening(onResult: (String) -> Unit) {
+        callback = onResult
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+        }
+        recognizer.startListening(intent)
+    }
+
+    actual fun stopListening() {
+        recognizer.stopListening()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/di/Modules.kt
@@ -11,6 +11,8 @@ expect val dataStoreModule: Module
 
 expect val platformModule: Module
 
+expect val speechToTextModule: Module
+
 // Currently, you cannot inject an Object-C object using KOIN,
 // so you have to wrap it in a Kotlin class...
 // see: https://github.com/InsertKoinIO/koin/issues/1492

--- a/composeApp/src/commonMain/kotlin/di/initKoin.kt
+++ b/composeApp/src/commonMain/kotlin/di/initKoin.kt
@@ -6,6 +6,6 @@ import org.koin.dsl.KoinAppDeclaration
 fun initKoin(config: KoinAppDeclaration? = null) {
     startKoin {
         config?.invoke(this)
-        modules(sharedModule, platformModule, dataStoreModule)
+        modules(sharedModule, platformModule, dataStoreModule, speechToTextModule)
     }
 }

--- a/composeApp/src/commonMain/kotlin/services/SpeechToText.kt
+++ b/composeApp/src/commonMain/kotlin/services/SpeechToText.kt
@@ -1,0 +1,14 @@
+package services
+
+import dev.bluefalcon.ApplicationContext
+
+/**
+ * Simple cross-platform speech recognition service.
+ */
+expect class SpeechToText(context: ApplicationContext) {
+    /** Start listening and return partial or final results via [onResult]. */
+    fun startListening(onResult: (String) -> Unit)
+
+    /** Stop listening for speech input. */
+    fun stopListening()
+}

--- a/composeApp/src/iosMain/kotlin/di/Modules.ios.kt
+++ b/composeApp/src/iosMain/kotlin/di/Modules.ios.kt
@@ -12,6 +12,7 @@ import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
 import platform.UIKit.UIView
 import robo.ndipatri.robogaggia.proto_datastore_kmm.TelemetryProtoData
+import services.SpeechToText
 
 actual val platformModule = module {
     single {
@@ -35,4 +36,8 @@ actual val dataStoreModule = module {
 
         createDataStore(fileSystem = FileSystem.SYSTEM, producePath = { producePath().toPath() })
     }
+}
+
+actual val speechToTextModule = module {
+    single { SpeechToText(get<ApplicationContextWrapper>().applicationContext) }
 }

--- a/composeApp/src/iosMain/kotlin/services/SpeechToText.ios.kt
+++ b/composeApp/src/iosMain/kotlin/services/SpeechToText.ios.kt
@@ -1,0 +1,50 @@
+package services
+
+import dev.bluefalcon.ApplicationContext
+import platform.AVFoundation.AVAudioEngine
+import platform.AVFoundation.AVAudioSession
+import platform.Speech.SFSpeechAudioBufferRecognitionRequest
+import platform.Speech.SFSpeechRecognitionTask
+import platform.Speech.SFSpeechRecognizer
+import platform.Speech.SFSpeechRecognizerAuthorizationStatus
+import platform.Speech.requestAuthorization
+
+actual class SpeechToText actual constructor(private val context: ApplicationContext) {
+    private val audioEngine = AVAudioEngine()
+    private val recognizer = SFSpeechRecognizer()
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest? = null
+    private var recognitionTask: SFSpeechRecognitionTask? = null
+    private var callback: ((String) -> Unit)? = null
+
+    actual fun startListening(onResult: (String) -> Unit) {
+        callback = onResult
+        requestAuthorization { }
+
+        val audioSession = AVAudioSession.sharedInstance()
+        audioSession.setCategory("record")
+        audioSession.setMode("measurement")
+        audioSession.setActive(true, null)
+
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        val inputNode = audioEngine.inputNode
+        val recordingFormat = inputNode.outputFormatForBus(0)
+        inputNode.installTapOnBus(0, 1024, recordingFormat) { buffer, _ ->
+            recognitionRequest?.appendAudioPCMBuffer(buffer)
+        }
+
+        audioEngine.prepare()
+        audioEngine.startAndReturnError(null)
+
+        recognitionTask = recognizer.recognitionTaskWithRequest(recognitionRequest!!, resultHandler = { result, _ ->
+            result?.bestTranscription?.formattedString?.let { text ->
+                callback?.invoke(text)
+            }
+        })
+    }
+
+    actual fun stopListening() {
+        audioEngine.stop()
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+    }
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -2,10 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>We need to use bluetooth to connect to your device.</string>
-	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>We need to use bluetooth to connect to your device.</string>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>We need to use bluetooth to connect to your device.</string>
+        <key>NSBluetoothPeripheralUsageDescription</key>
+        <string>We need to use bluetooth to connect to your device.</string>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>Microphone access is needed for speech recognition.</string>
+        <key>NSSpeechRecognitionUsageDescription</key>
+        <string>Speech recognition is needed to convert your voice to text.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary
- add SpeechToText service with expect/actual implementations
- wire SpeechToText into DI modules
- request microphone permissions on Android and iOS

## Testing
- `./gradlew assemble` *(fails: mqtt.server.address must not be null)*

------
https://chatgpt.com/codex/tasks/task_e_68667e5605548331975791d03b26a1d3