### PR TITLE
Add microphone FAB with speech logging

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -58,6 +58,7 @@ kotlin {
                 implementation(compose.ui)
                 implementation(compose.components.resources)
                 implementation(compose.components.uiToolingPreview)
+                implementation(compose.materialIconsExtended)
 
                 api(libs.koin.core)
                 implementation(libs.koin.compose)

--- a/composeApp/src/commonMain/kotlin/content/ScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/content/ScreenContent.kt
@@ -43,6 +43,13 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
+import services.SpeechToText
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
 import robogaggiamultiplatform.composeapp.generated.resources.Res
 import robogaggiamultiplatform.composeapp.generated.resources.dark_circuitboard
 import robogaggiamultiplatform.composeapp.generated.resources.temp_is
@@ -262,6 +269,18 @@ fun ScreenContent(
                             textAlign = TextAlign.Center
                         )
                     }
+                }
+            }
+
+            KoinContext {
+                val speechToText = koinInject<SpeechToText>()
+                FloatingActionButton(
+                    onClick = { speechToText.startListening { println("*** Speech: $it") } },
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(20.dp)
+                ) {
+                    Icon(Icons.Default.Mic, contentDescription = "mic")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add Material icons dependency
- show a floating microphone button on every screen
- log recognized speech when the mic button is pressed

## Testing
- `./gradlew -version`
- `./gradlew assemble` *(fails: `gradleLocalProperties` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686688ff02e4833198d7deb60aec3b5e