### PR TITLE
Add click sound on FAB

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/ndipatri/roboaggia/previews/ComposePreviews.kt
+++ b/composeApp/src/androidMain/kotlin/com/ndipatri/roboaggia/previews/ComposePreviews.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import com.ndipatri.roboaggia.MyApplication
 import di.dataStoreModule
+import di.soundModule
 import di.initKoin
 import di.platformModule
 import di.sharedModule
@@ -196,7 +197,7 @@ fun PreviewSteamingScreen() {
 fun PreviewDoneBrewingScreen() {
     if (GlobalContext.getOrNull() == null) {
         startKoin {
-            modules(sharedModule, platformModule, dataStoreModule)
+            modules(sharedModule, platformModule, dataStoreModule, soundModule)
         }
     }
 
@@ -214,7 +215,7 @@ fun PreviewDoneBrewingScreen() {
 fun PreviewLastBrewScreen() {
     if (GlobalContext.getOrNull() == null) {
         startKoin {
-            modules(sharedModule, platformModule, dataStoreModule)
+            modules(sharedModule, platformModule, dataStoreModule, soundModule)
         }
     }
 
@@ -230,7 +231,7 @@ fun PreviewLastBrewScreen() {
 fun PreviewBrewingScreen() {
     if (GlobalContext.getOrNull() == null) {
         startKoin {
-            modules(sharedModule, platformModule, dataStoreModule)
+            modules(sharedModule, platformModule, dataStoreModule, soundModule)
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/di/Modules.android.kt
+++ b/composeApp/src/androidMain/kotlin/di/Modules.android.kt
@@ -9,6 +9,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 import persistence.createDataStore
 import services.SpeechToText
+import services.ClickSound
 import robo.ndipatri.robogaggia.proto_datastore_kmm.TelemetryProtoData
 
 actual val platformModule = module {
@@ -26,4 +27,8 @@ actual val dataStoreModule = module {
 
 actual val speechToTextModule = module {
     single { SpeechToText(get<ApplicationContextWrapper>().applicationContext) }
+}
+
+actual val soundModule = module {
+    single { ClickSound(get<ApplicationContextWrapper>().applicationContext) }
 }

--- a/composeApp/src/androidMain/kotlin/services/ClickSound.android.kt
+++ b/composeApp/src/androidMain/kotlin/services/ClickSound.android.kt
@@ -1,0 +1,13 @@
+package services
+
+import android.media.AudioManager
+import android.media.ToneGenerator
+import dev.bluefalcon.ApplicationContext
+
+actual class ClickSound actual constructor(context: ApplicationContext) {
+    private val toneGenerator = ToneGenerator(AudioManager.STREAM_NOTIFICATION, 100)
+
+    actual fun play() {
+        toneGenerator.startTone(ToneGenerator.TONE_PROP_BEEP, 150)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/content/ScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/content/ScreenContent.kt
@@ -46,6 +46,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.KoinContext
 import org.koin.compose.koinInject
 import services.SpeechToText
+import services.ClickSound
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
@@ -276,10 +277,12 @@ fun ScreenContent(
 
         KoinContext {
             val speechToText = koinInject<SpeechToText>()
+            val clickSound = koinInject<ClickSound>()
             var isListening by remember { mutableStateOf(false) }
 
             FloatingActionButton(
                 onClick = {
+                    clickSound.play()
                     if (isListening) {
                         speechToText.stopListening()
                     } else {

--- a/composeApp/src/commonMain/kotlin/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/di/Modules.kt
@@ -13,6 +13,8 @@ expect val platformModule: Module
 
 expect val speechToTextModule: Module
 
+expect val soundModule: Module
+
 // Currently, you cannot inject an Object-C object using KOIN,
 // so you have to wrap it in a Kotlin class...
 // see: https://github.com/InsertKoinIO/koin/issues/1492

--- a/composeApp/src/commonMain/kotlin/di/initKoin.kt
+++ b/composeApp/src/commonMain/kotlin/di/initKoin.kt
@@ -6,6 +6,6 @@ import org.koin.dsl.KoinAppDeclaration
 fun initKoin(config: KoinAppDeclaration? = null) {
     startKoin {
         config?.invoke(this)
-        modules(sharedModule, platformModule, dataStoreModule, speechToTextModule)
+        modules(sharedModule, platformModule, dataStoreModule, speechToTextModule, soundModule)
     }
 }

--- a/composeApp/src/commonMain/kotlin/services/ClickSound.kt
+++ b/composeApp/src/commonMain/kotlin/services/ClickSound.kt
@@ -1,0 +1,7 @@
+package services
+
+import dev.bluefalcon.ApplicationContext
+
+expect class ClickSound(context: ApplicationContext) {
+    fun play()
+}

--- a/composeApp/src/iosMain/kotlin/di/Modules.ios.kt
+++ b/composeApp/src/iosMain/kotlin/di/Modules.ios.kt
@@ -13,6 +13,7 @@ import platform.Foundation.NSUserDomainMask
 import platform.UIKit.UIView
 import robo.ndipatri.robogaggia.proto_datastore_kmm.TelemetryProtoData
 import services.SpeechToText
+import services.ClickSound
 
 actual val platformModule = module {
     single {
@@ -40,4 +41,8 @@ actual val dataStoreModule = module {
 
 actual val speechToTextModule = module {
     single { SpeechToText(get<ApplicationContextWrapper>().applicationContext) }
+}
+
+actual val soundModule = module {
+    single { ClickSound(get<ApplicationContextWrapper>().applicationContext) }
 }

--- a/composeApp/src/iosMain/kotlin/services/ClickSound.ios.kt
+++ b/composeApp/src/iosMain/kotlin/services/ClickSound.ios.kt
@@ -1,0 +1,11 @@
+package services
+
+import dev.bluefalcon.ApplicationContext
+import platform.AudioToolbox.AudioServicesPlaySystemSound
+
+actual class ClickSound actual constructor(context: ApplicationContext) {
+    actual fun play() {
+        // 1104 is the 'Tock' system sound
+        AudioServicesPlaySystemSound(1104u)
+    }
+}


### PR DESCRIPTION
## Summary
- support new ClickSound service
- inject ClickSound in Android/iOS modules
- play sound on floating action button press
- include ClickSound in previews and Koin startup

## Testing
- `./gradlew test` *(fails: mqtt.server.address must not be null)*

------
https://chatgpt.com/codex/tasks/task_e_6866a75a48308331b9bb7708ec7594c1