### PR TITLE
Change FAB color when listening

### DIFF
--- a/composeApp/src/commonMain/kotlin/content/ScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/content/ScreenContent.kt
@@ -290,6 +290,7 @@ fun ScreenContent(
                     }
                     isListening = !isListening
                 },
+                backgroundColor = if (isListening) Color.Red else Color.Green,
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .padding(5.dp)


### PR DESCRIPTION
## Summary
- toggle FloatingActionButton color: red when listening, green when idle

## Testing
- `./gradlew tasks --all` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6866c37f4ea8833197310476d670f2ed