### PR TITLE
Integrate Anthropic SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This simulator pretends that it is the Robo Gaggia device: it emits telemetry an
 
 In order to use the GaggiaKMPSimulator, set the 'use.simulator' property in the [local.properties](local.properties) file of this project to 'true'.  The RGUI will, instead, use MQTT to communicate with the simulator.
 
+The application now also integrates the Anthropic SDK. Provide your `anthropic.api.key` in `local.properties` to enable AI features.
+
 Please see the [Gaggia KMP Simulator](https://github.com/ndipatri/GaggiaKMPSimulator) project for details on how to start the simulator and necessary local MQTT broker. 
 
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
 
                 // Storage
                 api(libs.datastore.core)
+                implementation(libs.anthropic.sdk)
             }
         }
 
@@ -129,6 +130,12 @@ buildkonfig {
             com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING,
             "PARTICLE_ACCESS_TOKEN",
             gradleLocalProperties(rootDir, providers).getProperty("particle.access.token")
+        )
+
+        buildConfigField(
+            com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING,
+            "ANTHROPIC_API_KEY",
+            gradleLocalProperties(rootDir, providers).getProperty("anthropic.api.key")
         )
     }
 }

--- a/default.local.properties
+++ b/default.local.properties
@@ -22,3 +22,6 @@ use.simulator = true
 # use Particle CLI tool:
 # particle token create --never-expires
 particle.access.token = XXX
+
+# Anthropic API key provided by Anthropic
+anthropic.api.key = YOUR_KEY_HERE

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ koinComposeMultiplatform = "1.2.0-Beta4"
 navigationCompose = "2.8.0-alpha02"
 lifecycleViewModel = "2.8.4"
 riveAndroid = "9.6.5"
+anthropic = "0.11"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -44,6 +45,7 @@ navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-co
 rive-android = { module = "app.rive:rive-android", version.ref = "riveAndroid" }
 
 datastore-core = { module = "androidx.datastore:datastore-core-okio", version.ref = "datastore" }
+anthropic-sdk = { module = "com.xemantic.anthropic:anthropic-sdk-kotlin", version.ref = "anthropic" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add anthropic SDK dependency and version
- expose `anthropic.api.key` for BuildKonfig
- document Anthropic key requirement

## Testing
- `./gradlew --version`
- `./gradlew test --dry-run` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6866d3035214833198bde807a687134f