### PR TITLE
Add MCP SDK for shared code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This simulator pretends that it is the Robo Gaggia device: it emits telemetry an
 In order to use the GaggiaKMPSimulator, set the 'use.simulator' property in the [local.properties](local.properties) file of this project to 'true'.  The RGUI will, instead, use MQTT to communicate with the simulator.
 
 The application now also integrates the Anthropic SDK. Provide your `anthropic.api.key` in `local.properties` to enable AI features.
+The application integrates the MCP Kotlin Multiplatform SDK to support the Model Context Protocol across Android and iOS.
 
 Please see the [Gaggia KMP Simulator](https://github.com/ndipatri/GaggiaKMPSimulator) project for details on how to start the simulator and necessary local MQTT broker. 
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
 
                 // Storage
                 api(libs.datastore.core)
+                implementation(libs.mcp.sdk)
                 implementation(libs.anthropic.sdk)
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ navigationCompose = "2.8.0-alpha02"
 lifecycleViewModel = "2.8.4"
 riveAndroid = "9.6.5"
 anthropic = "0.11"
+mcp = "0.5.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -46,6 +47,7 @@ rive-android = { module = "app.rive:rive-android", version.ref = "riveAndroid" }
 
 datastore-core = { module = "androidx.datastore:datastore-core-okio", version.ref = "datastore" }
 anthropic-sdk = { module = "com.xemantic.anthropic:anthropic-sdk-kotlin", version.ref = "anthropic" }
+mcp-sdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcp" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- integrate MCP Kotlin SDK in commonMain so it's available to Android and iOS
- update README to mention multiplatform MCP support

## Testing
- `./gradlew assemble --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6866e04dac408331909c9171c0219cea